### PR TITLE
feat: add quick action for most used prompts

### DIFF
--- a/frontend/popup.html
+++ b/frontend/popup.html
@@ -333,6 +333,22 @@
             margin-left: -7px;
             font-size: 0.8rem;
         }
+        .suggestedPrompts{
+            margin-bottom: 10px;
+        }
+        .suggestedPrompts .heading{
+            font-size: 12px;
+            text-align: left;
+            margin-bottom: 4px;
+        }
+        .suggestedPrompts .prompt{
+            padding: 2px 0px;
+            cursor: pointer;
+            color: -webkit-link;
+            cursor: pointer;
+            text-decoration: underline;
+            width: max-content;
+        }
     </style>
 </head>
 
@@ -396,13 +412,15 @@ Inspector Saab is constantly evolving, and while it's already powerful, some adv
 👉 Tip: Be specific in your instructions for the best results! Example:
 ✔️ "Make all buttons blue" (✅ Works well)
 ❌ "Make this site better" (🚨 Too vague, AI needs clearer instructions)
-
-Enjoy experimenting with the web, your way! 🎨✨
-                 <a class="suggest-feature-button" href="https://github.com/SarthakSri98/inspector-saab-frontend/issues" target="_blank">
-                <div >💡 Suggest a Feature</div>
-                </a>
-            </pre>
-        </div>
+</pre>
+<div class="suggestedPrompts">
+    <div class="heading">⭐️ Suggested Prompts :-</div>
+</div>
+<h4 style="text-align: left;">Enjoy experimenting with the web, your way! 🎨✨</h4>
+<a class="suggest-feature-button" href="https://github.com/SarthakSri98/inspector-saab-frontend/issues" target="_blank">
+    <div>💡 Suggest a Feature</div>
+</a>
+</div>
     </div>
 
     <script type="module" src="./popup.js"></script>

--- a/frontend/popup.js
+++ b/frontend/popup.js
@@ -14,6 +14,29 @@ function main() {
     const statusMessage = document.getElementById('status');
     const iconBar = document.getElementsByClassName('icon-bar')[0];
     const crossIcon = document.getElementsByClassName('cross-icon')[0];    
+    const suggestedPrompts = document.getElementsByClassName('suggestedPrompts')[0];
+    const mostUsedPrompts = [
+        "Make the text red",
+        "Add a scroll to top button",
+        "Hide the footer",
+        "Make all buttons green",
+        "Turn the page dark",
+    ];
+
+    for (let i = 0; i < mostUsedPrompts.length; i++) {
+        const prompText = mostUsedPrompts[i];
+        let prompt = document.createElement('div');
+        prompt.className = 'prompt'
+        prompt.textContent = `${i + 1}. ${prompText}.`;
+        prompt.onclick = () => {
+            descriptionArea.value = `${prompText}`
+            const closeHelpModal = document.getElementById('closeHelpModal');
+            if (closeHelpModal)
+                closeHelpModal.click()
+            applyChangesButton.click()
+        }
+        suggestedPrompts.append(prompt);
+    }
 
     crossIcon.addEventListener("click",  () => {
         const description = document.getElementById("description");


### PR DESCRIPTION
## Description
1. Added most-used prompts for quick action in popup.
2. Refactored pre tag to separate html from plain text.

Clicking on a particular prompt will prefill the input box, close the popup and initiate the action.

## 🔗 Related Issues

Fixes #5 

## 📸 Demo (screenshot or a video)

<details>
<summary>After</summary>
<img width="413" alt="Screenshot 2025-07-06 at 1 47 33 PM" src="https://github.com/user-attachments/assets/5ea0280e-1138-4d71-bf0a-34ec3e4639a6" />
</details>

---
> - Need help? Check our [Contributing Guidelines](../CONTRIBUTING.md) 